### PR TITLE
Fixed the current version to work with turbolinks.

### DIFF
--- a/lib/generators/mousetrap/install/templates/keybindings.js.coffee
+++ b/lib/generators/mousetrap/install/templates/keybindings.js.coffee
@@ -1,8 +1,8 @@
 $ ->
-	handleKeyBindings()
+  handleKeyBindings()
 
 $(document).on 'page:change', ->
-	handleKeyBindings()
+  handleKeyBindings()
 
 handleKeyBindings = ->
   # Hotkey binding to links with 'data-keybinding' attribute


### PR DESCRIPTION
Turbolinks requires the JS to listen also on the page:change event. Added this into the keybindings.js template.
