### PR TITLE
Added Mousetrap reset whenever keybindings get reloaded.

### DIFF
--- a/lib/generators/mousetrap/install/templates/keybindings.js.coffee
+++ b/lib/generators/mousetrap/install/templates/keybindings.js.coffee
@@ -5,6 +5,9 @@ $(document).on 'page:change', ->
   handleKeyBindings()
 
 handleKeyBindings = ->
+  # As turbolinks does not refresh the page, some old keybindings could be still present. Therefore a reset is required.
+  Mousetrap.reset()
+  
   # Hotkey binding to links with 'data-keybinding' attribute
   # Navigate link when hotkey pressed
   $('a[data-keybinding]').each (i, el) ->


### PR DESCRIPTION
It is required to reset the Mousetrap.js library as turbolinks does not refresh the page. Therefore some old keybindings might still be present.

To reproduce create the following steps:

1) Create a page which lists all entities of type X (index.html.erb)
2) Create a detail page for an entity of type X (show.html.erb) incl. an edit link (with keybinding 'e').
3) Enable turbolinks
4) Visit the index page, then navigate to one of the entities.
5) Go back to the index page and press 'e'. You get now to the edit view of the previous visited entity.
